### PR TITLE
カードの番号が一致しないときもフリップ動作をするよう修正

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -129,18 +129,43 @@
      */
     function tryGetCards(board) {
         if (board.firstCard.num !== board.secondCard.num) {
-            flipCard(board.firstCard);
-            flipCard(board.secondCard);
+            resetCards(board);
             board.isYourTurn = !board.isYourTurn;
         } else {
-            board.firstCard.body.off();
-            board.secondCard.body.off();
-
-            let player = board.isYourTurn ? board.players['you'] : board.players['rival'];
-            player.cards.push(board.firstCard, board.secondCard);
+            getCards(board);
         }
+    }
+
+    /**
+     * カードのフリップ動作を無効にしてプレイヤに渡す
+     * @param Board board 
+     */
+    function getCards(board) {
+        board.firstCard.body.off();
+        board.secondCard.body.off();
+
+        let player = board.isYourTurn ? board.players['you'] : board.players['rival'];
+        player.cards.push(board.firstCard, board.secondCard);
+
         board.firstCard = null;
         board.secondCard = null;
+    }
+
+    /**
+     * カードを裏返して次のカードを選べるようにする
+     * @param Board board 
+     */
+    function resetCards(board) {
+        board.secondCard.body.on('transitionend webkitTransitionEnd', function () {
+            // フリップ動作を無限ループしないようにイベントを無効にする
+            board.secondCard.body.off('transitionend webkitTransitionEnd');
+
+            flipCard(board.firstCard);
+            flipCard(board.secondCard);
+
+            board.firstCard = null;
+            board.secondCard = null;
+        });
     }
 
     init();


### PR DESCRIPTION
### Context

- #11
- 数字が違っていればカードを裏に戻しターンを次のプレイヤに移す

### Problem

<!-- 問題としている対象を書いてください -->

- 2枚のカードの数字が一致しなかった場合に2枚目のカードがフリップしない（ように見える）
- 2枚目を表にするアニメーションが実行されると同時に裏返しにされている

### Solution

<!-- どのようにこの問題を解決しようと考えているか -->

- 2枚目のカードを表にするアニメーション終了後に、裏返しのアクションを実行する
- jQueryのon()メソッドでトランザクション後に次の処理を実行できそう

```js
$("#target_obj").on('transitionend webkitTransitionEnd',function(){
  // CSSのtransitionプロパティで設定したものが終了した時に実行する内容
});
```

http://black-flag.net/jquery/20110406-2889.html

### Testing

<!-- テストコードが無い場合実行したテストをここで説明 -->

下記の記述を試す

```js
        board.secondCard.body.on('transitionend webkitTransitionEnd', function () {
            flipCard(board.firstCard);
            flipCard(board.secondCard);
            board.firstCard = null;
            board.secondCard = null;
        });
```

ブラウザで確認すると、カードが完全に表になった後に裏返す動作が開始されている

しかし、consoleを確認すると次のエラーが発生している

```
main.js:103 Uncaught TypeError: Cannot read property 'body' of null
    at flipCard (main.js:103)
    at HTMLDivElement.<anonymous> (main.js:163)
    at HTMLDivElement.dispatch (jquery-3.4.1.slim.min.js:2)
    at HTMLDivElement.v.handle (jquery-3.4.1.slim.min.js:2)
```

`transitionend`をトリガーにフリップ動作(transition)をしているため無限ループになっている

この処理は一度だけ実行すれば良いので下記のように修正する

```js
        board.secondCard.body.on('transitionend webkitTransitionEnd', function () {
            // フリップ動作を無限ループしないようにイベントを無効にする
            board.secondCard.body.off('transitionend webkitTransitionEnd');

            flipCard(board.firstCard);
            flipCard(board.secondCard);

            board.firstCard = null;
            board.secondCard = null;
        });
```

