### PR TITLE
ゲーム開始後は設定の適用ボタンを非活性にする

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -51,6 +51,7 @@
         constructor() {
             this.stage = $("#stage");
             this.startBtn = $('#btn-start-memory');
+            this.applyBtn = $('#btn-apply-setting');
             this.rivalStrengthLevel = $('#rival-strength-level');
             this.progressBars = {};
             this.numOfCards = {};
@@ -104,6 +105,8 @@
             this.stage.off();
             this.startBtn.off();
             this.startBtn.addClass('disabled');
+            this.applyBtn.addClass('disabled');
+            this.applyBtn.attr('disabled', true);
         }
         activateSettings() {
             this.activateInputSuit();

--- a/memory_game.html
+++ b/memory_game.html
@@ -110,7 +110,7 @@
                             <input id="input-rival-strength-level" type="hidden" name="rival-strength-level" value=""
                                 disabled>
                         </div>
-                        <button type="submit" class="btn btn-info btn-lg btn-block">適用</button>
+                        <button id="btn-apply-setting" type="submit" class="btn btn-info btn-lg btn-block">適用</button>
                         <a href="/memory_game.html" class="btn btn-dark btn-lg btn-block">リセット</a>
                     </form>
                 </div>


### PR DESCRIPTION
## 変更の種類
<!-- 変更の種類にチェックを入れてください, 例: Viewの変更 →  UIの変更 -->
- [ ] バグFix
- [x] 新規実装 (破壊的変更でない機能の追加)
- [ ] 破壊的変更 (既存機能が期待通りの動作をしなくなるような変更)
- [ ] コンフィグの変更
- [ ] ビルドシステムに関わる変更 (例: composer, npm, CircleCI)
- [ ] ビジネスロジックの実装
- [ ] UIの変更
  - [ ] 変更内容のスクリーンショットもしくは動画（GIF等）が貼ってある
- [ ] スタイルの変更 (フォーマット, 改行, 空白, etc...)
- [ ] リファクタリング (コードの振る舞いに影響を与えない変更)
- [ ] ドキュメントの変更
- [ ] テストの追加 (新規追加や欠けているテストの追加)
- [ ] それ以外のコードの動作に影響を与えない変更
## Context
<!-- このPull Requestが属するコンテキストを書いてください -->
<!-- 例:-->
<!-- 良い例: - Refs #issueナンバー -->
<!-- 良い例: - Close #15 (PRのマージと同時にissueをCloseする場合) -->
<!-- 良い例: - JIRAチケットURL -->
<!-- 良い例: - 仕様書URL -->
<!-- 良い例: - デザインURL -->
<!-- 良い例: - 依存するPull Request No e.g. #13 -->
- https://github.com/OnoYuta/app-memory-game/issues/18
- ゲーム開始後は設定の適用ボタンを非活性にする

## Problem
<!-- 問題としている対象を書いてください -->
<!-- 例: -->
<!-- 良い例: - チケットNo.○○の~~を実装するため○○を追加する必要がある. URL: ~ -->
<!-- 良い例: - 現在○○だが○○なため、○○といった問題を抱えている. その原因は○○のため -->
<!-- 悪い例: - ログインを実装したい -->
- 適用ボタンをクリックするとゲーム進捗がリセットされるがユーザにわかりづらい

## Solution
<!-- どのようにこの問題を解決しようと考えているか -->
<!-- 例 -->
<!-- 良い例: - ○○の問題に対して○○というソリューションを使うことで問題を解決出来る. URL: ~ -->
<!-- 良い例: - ○○といったカラム名を○○に修正することで○○の問題が解決する. なぜなら〜だから -->
<!-- 良い例: - ○○に○を追加する. ただ○○という点については悩んでいるのでディスカッションしたい -->
<!-- 良い例: - 実装のスクリーンショット.jpg -->
<!-- 悪い例: - 画面を追加 -->
- ゲーム開始後はsubbmitボタンを非活性にする
- subbmitボタンにidをつける
- disabled属性を追加して送信できないようにする